### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/identity.yaml
+++ b/identity.yaml
@@ -1,10 +1,3 @@
 enabled: true
 dropdown:
   enabled: false
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/identity


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
