### PR TITLE
Google Fonts URL change

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 @import url(font-awesome.min.css);
-@import url("http://fonts.googleapis.com/css?family=Source+Sans+Pro:300");
+@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300");
 
 /*
 	Identity by HTML5 UP

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -3,7 +3,7 @@
 @import 'libs/mixins';
 @import 'libs/skel';
 @import 'font-awesome.min.css';
-@import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:300');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300');
 
 /*
 	Identity by HTML5 UP


### PR DESCRIPTION
Google now mandate fonts be served over HTTPS or else the font fails to load.